### PR TITLE
refactor(button): use 'ViewContainerRef#createComponent' to create MatProgressSpinner instance

### DIFF
--- a/projects/dev-app/karma.conf.js
+++ b/projects/dev-app/karma.conf.js
@@ -9,16 +9,20 @@ module.exports = function (config) {
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
-      require('karma-coverage-istanbul-reporter'),
+      require('karma-coverage'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
-    coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, '../../coverage/dev-app'),
-      reports: ['html', 'lcovonly', 'text-summary'],
-      fixWebpackSourcePaths: true
+    coverageReporter: {
+      dir: require('path').join(__dirname, '../coverage/dev-app'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' },
+        { type: 'lcovonly' },
+      ]
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,

--- a/projects/docs/karma.conf.js
+++ b/projects/docs/karma.conf.js
@@ -9,16 +9,20 @@ module.exports = function (config) {
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
-      require('karma-coverage-istanbul-reporter'),
+      require('karma-coverage'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
-    coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, '../../coverage/docs'),
-      reports: ['html', 'lcovonly', 'text-summary'],
-      fixWebpackSourcePaths: true
+    coverageReporter: {
+      dir: require('path').join(__dirname, '../coverage/docs'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' },
+        { type: 'lcovonly' },
+      ]
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,

--- a/projects/extensions-moment-adapter/karma.conf.js
+++ b/projects/extensions-moment-adapter/karma.conf.js
@@ -9,16 +9,20 @@ module.exports = function (config) {
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
-      require('karma-coverage-istanbul-reporter'),
+      require('karma-coverage'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
-    coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, '../../coverage'),
-      reports: ['html', 'lcovonly'],
-      fixWebpackSourcePaths: true
+    coverageReporter: {
+      dir: require('path').join(__dirname, '../coverage'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' },
+        { type: 'lcovonly' },
+      ]
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,

--- a/projects/extensions/button/button-loading.directive.spec.ts
+++ b/projects/extensions/button/button-loading.directive.spec.ts
@@ -1,0 +1,51 @@
+import { Component } from '@angular/core';
+import { waitForAsync, TestBed } from '@angular/core/testing';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
+import { By } from '@angular/platform-browser';
+import { MatButtonLoadingDirective } from './button-loading.directive';
+import { MtxButtonModule } from './button.module';
+
+@Component({
+  selector: 'test-app',
+  template: ` <button mat-button [loading]="loading">Test Button</button> `,
+})
+class TestApp {
+  public loading: boolean = false;
+}
+
+describe('ButtonLoadingDirective', () => {
+  beforeEach(waitForAsync(() => {
+    TestBed.configureTestingModule({
+      imports: [MatButtonModule, MtxButtonModule],
+      declarations: [MatButtonLoadingDirective, TestApp],
+    });
+
+    TestBed.compileComponents();
+  }));
+  it('button loading', () => {
+    const fixture = TestBed.createComponent(TestApp);
+    const testComponent = fixture.debugElement.componentInstance;
+    const buttonDebugElement = fixture.debugElement.query(By.css('button'))!;
+    const buttonNativeElement = fixture.nativeElement.querySelector('button');
+    testComponent.loading = true;
+    fixture.detectChanges();
+    expect(buttonDebugElement.nativeElement.classList.contains('mat-button-loading')).toBe(true);
+    expect(buttonNativeElement.disabled).withContext('Expected button to be disabled').toBeTrue();
+    const spinner1 = fixture.debugElement.query(
+      By.directive(MatProgressSpinner)
+    )!.componentInstance;
+    expect(spinner1).withContext('Expected spinner to be existed').toBeTruthy();
+
+    testComponent.loading = false;
+    fixture.detectChanges();
+    expect(buttonDebugElement.nativeElement.classList.contains('mat-button-loading')).toBe(false);
+    expect(buttonNativeElement.disabled)
+      .withContext('Expected button not to be disabled')
+      .toBeFalse();
+    const spinner2 = fixture.debugElement.query(
+      By.directive(MatProgressSpinner)
+    )?.componentInstance;
+    expect(spinner2).withContext('Expected spinner to be not existed').toBeFalsy();
+  });
+});

--- a/projects/extensions/button/button-loading.directive.ts
+++ b/projects/extensions/button/button-loading.directive.ts
@@ -24,7 +24,6 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
              button[mat-mini-fab][loading]`,
 })
 export class MatButtonLoadingDirective implements OnChanges {
-  private spinnerFactory: ComponentFactory<MatProgressSpinner>;
   private spinner!: ComponentRef<MatProgressSpinner> | null;
 
   @Input()
@@ -50,12 +49,9 @@ export class MatButtonLoadingDirective implements OnChanges {
 
   constructor(
     private matButton: MatButton,
-    private componentFactoryResolver: ComponentFactoryResolver,
     private viewContainerRef: ViewContainerRef,
     private renderer: Renderer2
-  ) {
-    this.spinnerFactory = this.componentFactoryResolver.resolveComponentFactory(MatProgressSpinner);
-  }
+  ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
     if (!changes.loading) {
@@ -75,7 +71,7 @@ export class MatButtonLoadingDirective implements OnChanges {
 
   private createSpinner(): void {
     if (!this.spinner) {
-      this.spinner = this.viewContainerRef.createComponent(this.spinnerFactory);
+      this.spinner = this.viewContainerRef.createComponent(MatProgressSpinner);
       this.spinner.instance.color = this.color;
       this.spinner.instance.diameter = 20;
       this.spinner.instance.mode = 'indeterminate';

--- a/projects/extensions/karma.conf.js
+++ b/projects/extensions/karma.conf.js
@@ -9,16 +9,20 @@ module.exports = function (config) {
       require('karma-jasmine'),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
-      require('karma-coverage-istanbul-reporter'),
+      require('karma-coverage'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
       clearContext: false // leave Jasmine Spec Runner output visible in browser
     },
-    coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, '../../coverage/extensions'),
-      reports: ['html', 'lcovonly', 'text-summary'],
-      fixWebpackSourcePaths: true
+    coverageReporter: {
+      dir: require('path').join(__dirname, '../coverage/extensions'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'text-summary' },
+        { type: 'lcovonly' },
+      ]
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,


### PR DESCRIPTION
Angular V13 no longer requires Component factories, so use 'ViewContainerRef#createComponent' to create MatProgressSpinner instance. Besides, add some unit test for mat button loading status.