### PR TITLE
feat(datetimepicker): add `yearInput` display and parse format

### DIFF
--- a/projects/dev-app/src/app/datetimepicker/datetimepicker-demo.module.ts
+++ b/projects/dev-app/src/app/datetimepicker/datetimepicker-demo.module.ts
@@ -32,12 +32,14 @@ import { DatetimeAdapter, MTX_DATETIME_FORMATS } from '@ng-matero/extensions/cor
         parse: {
           dateInput: 'YYYY-MM-DD',
           monthInput: 'MMMM',
+          yearInput: 'YYYY',
           timeInput: 'HH:mm',
           datetimeInput: 'YYYY-MM-DD HH:mm',
         },
         display: {
           dateInput: 'YYYY-MM-DD',
           monthInput: 'MMMM',
+          yearInput: 'YYYY',
           timeInput: 'HH:mm',
           datetimeInput: 'YYYY-MM-DD HH:mm',
           monthYearLabel: 'YYYY MMMM',

--- a/projects/extensions/core/datetime/datetime-formats.ts
+++ b/projects/extensions/core/datetime/datetime-formats.ts
@@ -4,12 +4,14 @@ export interface MtxDatetimeFormats {
   parse: {
     dateInput?: any;
     monthInput?: any;
+    yearInput?: any;
     timeInput?: any;
     datetimeInput?: any;
   };
   display: {
     dateInput: any;
     monthInput: any;
+    yearInput?: any;
     timeInput: any;
     datetimeInput: any;
     monthYearLabel: any;

--- a/projects/extensions/datetimepicker/datetimepicker-input.ts
+++ b/projects/extensions/datetimepicker/datetimepicker-input.ts
@@ -320,6 +320,8 @@ export class MtxDatetimepickerInput<D>
         return this._dateFormats.display.timeInput;
       case 'month':
         return this._dateFormats.display.monthInput;
+      case 'year':
+        return this._dateFormats.display.yearInput;
     }
   }
 
@@ -338,6 +340,9 @@ export class MtxDatetimepickerInput<D>
         break;
       case 'month':
         parseFormat = this._dateFormats.parse.monthInput;
+        break;
+      case 'year':
+        parseFormat = this._dateFormats.parse.yearInput;
         break;
     }
     if (!parseFormat) {


### PR DESCRIPTION
Hey,

For my issue raised in https://github.com/ng-matero/extensions/issues/134 I have added support for `yearInput`. To make it backwards compatible with existing usages of this datepickers and current behavior the `yearInput` for display is optional such that when asking for a format within the datepicker it will return undefined ( like existing behavior ).

Previous behavior will use the default display method:
![image](https://user-images.githubusercontent.com/4212850/195837803-e7949e67-5236-4d96-a50e-71f035be4d0b.png)

New behavior when specifying the yearInput format:
```ts
    {
      provide: MTX_DATETIME_FORMATS,
      useValue: {
        parse: {
          dateInput: 'YYYY-MM-DD',
          monthInput: 'MMMM',
          yearInput: 'YYYY',
          timeInput: 'HH:mm',
          datetimeInput: 'YYYY-MM-DD HH:mm',
        },
        display: {
          dateInput: 'YYYY-MM-DD',
          monthInput: 'MMMM',
          yearInput: 'YYYY',
          timeInput: 'HH:mm',
          datetimeInput: 'YYYY-MM-DD HH:mm',
          monthYearLabel: 'YYYY MMMM',
          dateA11yLabel: 'LL',
          monthYearA11yLabel: 'MMMM YYYY',
          popupHeaderDateLabel: 'MMM DD, ddd',
        },
      },
    },
```

We will get the following result:
![image](https://user-images.githubusercontent.com/4212850/195837707-48a9feb2-1832-427d-a0e2-b37d80791676.png)
