### PR TITLE
fix(datepicker): unable to put in 0:00 in 24 hour clock

### DIFF
--- a/projects/extensions/datetimepicker/time.ts
+++ b/projects/extensions/datetimepicker/time.ts
@@ -198,7 +198,8 @@ export class MtxTimeInput implements OnDestroy {
     }
 
     const value = coerceNumberProperty(this.inputElement?.value ?? null);
-    if (value) {
+    // if this._min === 0, we should allow 0
+    if (value || (this._min === 0 && value === 0)) {
       const clampedValue = Math.min(Math.max(value, this._min), this._max);
       if (clampedValue !== value) {
         this.writeValue(clampedValue);


### PR DESCRIPTION
This patch will resolve a problem one of our testers internally found: within the 24 hour mode being unable to put in 0:00, or any value starting with 0:xx

The code itself will check if the minimum allowed hour = 0, and if it does it will allow you to put in 0. Just checking for value == 0, creates a problem in the `twelvehour` mode since the clamping around min/max will set the value to be 01 and won't allow you to remove the '1' causing you unable to edit the field at all.