### PR TITLE
Datepicker - issues with min/max while in twelvehour mode

### DIFF
--- a/projects/dev-app/src/app/datetimepicker/datetimepicker-demo.component.html
+++ b/projects/dev-app/src/app/datetimepicker/datetimepicker-demo.component.html
@@ -56,7 +56,7 @@
     <mtx-datetimepicker-toggle [for]="timeAMPMPickerManual" matSuffix></mtx-datetimepicker-toggle>
     <mtx-datetimepicker #timeAMPMPickerManual startView="month" [timeInterval]="5"
                         [timeInput]="true" [twelvehour]="true"></mtx-datetimepicker>
-    <input [mtxDatetimepicker]="timeAMPMPickerManual"
+    <input [mtxDatetimepicker]="timeAMPMPickerManual" [max]="tomorrow" [min]="today"
            autocomplete="false" formControlName="timeAMPMManual" matInput required>
     <mat-error *ngIf="group.get('timeAMPMManual')?.errors?.required">required</mat-error>
     <mat-error *ngIf="group.get('timeAMPMManual')?.errors?.mtxDatetimepickerMin">min</mat-error>

--- a/projects/extensions/datetimepicker/calendar.html
+++ b/projects/extensions/datetimepicker/calendar.html
@@ -122,6 +122,7 @@
       <mtx-clock (_userSelection)="_userSelected()"
                  (activeDateChange)="_onActiveDateChange($event)"
                  (selectedChange)="_dialTimeSelected($event)"
+                 [AMPM]="_AMPM"
                  [dateFilter]="dateFilter"
                  [interval]="timeInterval"
                  [maxDate]="maxDate"

--- a/projects/extensions/datetimepicker/time.html
+++ b/projects/extensions/datetimepicker/time.html
@@ -44,6 +44,7 @@
 
 <mtx-clock (selectedChange)="_timeSelected($event)"
            (activeDateChange)="_onActiveDateChange($event)"
+           [AMPM]="AMPM"
            [dateFilter]="dateFilter"
            [interval]="interval"
            [maxDate]="maxDate"


### PR DESCRIPTION
Hey,

We found some issues related to the twelvehour mode while also having a min/max. This PR will resolve some of them:

- while in either AM or PM, if you are unable to swap to the other time don't allow the AM/PM to be swapped:
example of this would be when your active time is on 15:00 and you have a minTime on the same date at 12:00, swapping from PM to AM would change the clock to 3:00 however this is not allowed and because of a clamp in the calendar your datetime is now set to 12:00 which seems kinda random for a user. ( this has been resolved within this PR ).

- Clock didn't create the hours correctly because it would only look at hours 1-12, if these hours all would be disabled, then in PM mode all hours will also be disabled. ( this has also been fixed within this PR ).

- Refactored clock `_hours` to use the value correctly e.g. now we have `{ value: 15, displayValue: '3' .... }` for the twelvehour clock, this will cause us to always have the correct value. Clock now has a property of AM/PM so we know exactly what hours we need to use. 

Because of these bugs, I had to disable the twelvehour mode completely until these are fixed within our production application. Please review / test.

( these changes should only affect twelvehour mode )