### PR TITLE
fix: dateTimePicker with Moment/Luxon using adapter option useUtc breaks time selection

### DIFF
--- a/projects/dev-app/src/app/datetimepicker/datetimepicker-demo.module.ts
+++ b/projects/dev-app/src/app/datetimepicker/datetimepicker-demo.module.ts
@@ -5,7 +5,10 @@ import { SharedModule } from '../shared.module';
 import { MTX_DATETIME_FORMATS } from '@ng-matero/extensions/core';
 import { MtxDatetimepickerModule } from '@ng-matero/extensions/datetimepicker';
 import { MtxMomentDatetimeModule } from '@ng-matero/extensions-moment-adapter';
-
+import {
+  MAT_MOMENT_DATE_ADAPTER_OPTIONS,
+  MatMomentDateAdapterOptions,
+} from '@angular/material-moment-adapter';
 import { DatetimepickerDemoComponent } from './datetimepicker-demo.component';
 
 @NgModule({
@@ -39,6 +42,13 @@ import { DatetimepickerDemoComponent } from './datetimepicker-demo.component';
           popupHeaderDateLabel: 'MMM DD, ddd',
         },
       },
+    },
+    {
+      provide: MAT_MOMENT_DATE_ADAPTER_OPTIONS,
+      // for testing date adapter settings
+      useValue: {
+        useUtc: false,
+      } as MatMomentDateAdapterOptions,
     },
   ],
 })

--- a/projects/extensions-luxon-adapter/adapter/luxon-datetime-adapter.ts
+++ b/projects/extensions-luxon-adapter/adapter/luxon-datetime-adapter.ts
@@ -66,16 +66,18 @@ export class LuxonDatetimeAdapter extends DatetimeAdapter<DateTime> {
     }
 
     // Luxon uses 1-indexed months so we need to add one to the month.
-    let result = DateTime.fromObject({ year, month: month + 1, day, hour, minute });
+    let result;
     if (this._useUtc) {
-      result = result.toUTC();
+      result = DateTime.utc(year, month + 1, day, hour, minute);
+    } else {
+      result = DateTime.local(year, month + 1, day, hour, minute);
     }
 
     if (!result.isValid) {
       throw Error(`Invalid date "${day}" for month with index "${month}".`);
     }
 
-    return result;
+    return result.setLocale(this.locale);
   }
 
   getFirstDateOfMonth(date: DateTime): DateTime {

--- a/projects/extensions-moment-adapter/adapter/moment-datetime-adapter.ts
+++ b/projects/extensions-moment-adapter/adapter/moment-datetime-adapter.ts
@@ -96,9 +96,11 @@ export class MomentDatetimeAdapter extends DatetimeAdapter<Moment> {
       throw Error(`Invalid minute "${minute}". Minute has to be between 0 and 59.`);
     }
 
-    let result = moment({ year, month, date, hour, minute });
+    let result;
     if (this._useUtc) {
-      result = result.utc();
+      result = moment.utc({ year, month, date, hour, minute });
+    } else {
+      result = moment({ year, month, date, hour, minute });
     }
 
     // If the result isn't valid, the date must have been out of bounds for this month.
@@ -106,7 +108,7 @@ export class MomentDatetimeAdapter extends DatetimeAdapter<Moment> {
       throw Error(`Invalid date "${date}" for month with index "${month}".`);
     }
 
-    return result;
+    return result.locale(this.locale);
   }
 
   getFirstDateOfMonth(date: Moment): Moment {


### PR DESCRIPTION
Hey,

I managed to reproduce the issue #172 on the dev server and went to investigate I could reproduce it on the dev project but not  in my own projects likely because I overwrite the date adapter for a specific usecase. 

With these changes the issues of #172 should be resolved for both Moment and Luxon date adatpers, and correctly aligning the locale in the internal objects.

Can you verify that the problem goes away with this?