### PR TITLE
fix(datetimePicker): do not set time when mtxDatetimepickerFilter is …

### DIFF
--- a/projects/extensions/datetimepicker/clock.ts
+++ b/projects/extensions/datetimepicker/clock.ts
@@ -402,6 +402,18 @@ export class MtxClock<D> implements AfterContentInit, OnDestroy, OnChanges {
       );
     }
 
+    // if there is a dateFilter, check if the date is allowed if it is not then do not set/emit new date
+    // https://github.com/ng-matero/extensions/issues/244
+    if (
+      this.dateFilter &&
+      !this.dateFilter(
+        date,
+        this._hourView ? MtxDatetimepickerFilterType.HOUR : MtxDatetimepickerFilterType.MINUTE
+      )
+    ) {
+      return;
+    }
+
     this._timeChanged = true;
     this.activeDate = date;
     this._changeDetectorRef.markForCheck();


### PR DESCRIPTION
This commit solves the issue in #244 

Current Behavior:
We disable visible the hours and minutes on the clock however we do not prevent it from being clicked/selected

New Behavior:
Visually disabled hours and minutes cannot be selected when clicking on them

Note:
Users are still able to put in a time by using the input fields when using, `[timeInput]="true"` or directly writing in the `<input>` field and it getting parsed into a filtered time.

@nzbin can you apply this to current and previous versions of the library?