### PR TITLE
fix: 修复Router url截取问题

### DIFF
--- a/projects/docs/src/app/pages/component-viewer/component-viewer.ts
+++ b/projects/docs/src/app/pages/component-viewer/component-viewer.ts
@@ -46,7 +46,7 @@ export class ComponentViewer implements OnDestroy {
 
     this._router.events.pipe(startWith(this._router)).subscribe(s => {
       if (s instanceof Router || s instanceof NavigationEnd) {
-        this.componentId = s.url.split('/')[2];
+        this.componentId = s.url.split('/').pop()??'';
         this._componentPageTitle.title = this.componentId;
       }
     });

--- a/projects/docs/src/app/pages/component-viewer/component-viewer.ts
+++ b/projects/docs/src/app/pages/component-viewer/component-viewer.ts
@@ -46,7 +46,8 @@ export class ComponentViewer implements OnDestroy {
 
     this._router.events.pipe(startWith(this._router)).subscribe(s => {
       if (s instanceof Router || s instanceof NavigationEnd) {
-        this.componentId = s.url.split('/').pop()??'';
+        const fragments = s.url.split('/');
+        this.componentId = fragments[2]??fragments[1];
         this._componentPageTitle.title = this.componentId;
       }
     });


### PR DESCRIPTION
触发方法：先随意点一个组件进去->点击guides->点击get start-> 点击components ->点击components
https://github.com/ng-matero/extensions/assets/22205542/3047b24e-39c7-4bd2-bc6a-44bf36474ea8


原因这里一直拿的[2]是undifined。第一次能设置成功是因为在组件ComponentCategoryList的init中设置了值，然后在进入组件路由后会加载路由变化的订阅，导致仅有一段的路由变为undefined
![image](https://github.com/ng-matero/extensions/assets/22205542/80ec17d5-d779-4efc-baee-c54bfecef208)
