### PR TITLE
feat: ability to add custom header component as input

### DIFF
--- a/projects/dev-app/src/app/datetimepicker/datetimepicker-demo.component.html
+++ b/projects/dev-app/src/app/datetimepicker/datetimepicker-demo.component.html
@@ -170,6 +170,24 @@
     }
   </mat-form-field>
 
+  <mat-form-field [color]="themeColor">
+    <mat-label>Custom Header</mat-label>
+    <mtx-datetimepicker-toggle [for]="datetimePickerCustomHeader" matSuffix></mtx-datetimepicker-toggle>
+    <mtx-datetimepicker #datetimePickerCustomHeader startView="month" [timeInterval]="5"
+    [calendarHeaderComponent]="customHeader"></mtx-datetimepicker>
+    <input [mtxDatetimepicker]="datetimePickerCustomHeader" [max]="tomorrow" [min]="today"
+      autocomplete="false" formControlName="dateTime" matInput required>
+    @if (group.get('dateTime')?.errors?.required) {
+      <mat-error>required</mat-error>
+    }
+    @if (group.get('dateTime')?.errors?.mtxDatetimepickerMin) {
+      <mat-error>min</mat-error>
+    }
+    @if (group.get('dateTime')?.errors?.mtxDatetimepickerMax) {
+      <mat-error>max</mat-error>
+    }
+  </mat-form-field>
+
   <button mat-button>Submit</button>
 </form>
 

--- a/projects/dev-app/src/app/datetimepicker/datetimepicker-demo.component.ts
+++ b/projects/dev-app/src/app/datetimepicker/datetimepicker-demo.component.ts
@@ -1,4 +1,13 @@
-import { Component, OnDestroy, OnInit } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  Inject,
+  OnDestroy,
+  OnInit,
+  Optional,
+  inject,
+} from '@angular/core';
 import {
   FormsModule,
   ReactiveFormsModule,
@@ -6,15 +15,29 @@ import {
   UntypedFormGroup,
   Validators,
 } from '@angular/forms';
-import { MatButton } from '@angular/material/button';
+import { MatButton, MatButtonModule } from '@angular/material/button';
 import { MatCard } from '@angular/material/card';
-import { DateAdapter, ThemePalette } from '@angular/material/core';
+import {
+  DateAdapter,
+  MAT_DATE_FORMATS,
+  MatDateFormats,
+  ThemePalette,
+} from '@angular/material/core';
 import { MatError, MatFormField, MatLabel, MatSuffix } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
 import { MatRadioButton, MatRadioGroup } from '@angular/material/radio';
 import { provideMomentDatetimeAdapter } from '@ng-matero/extensions-moment-adapter';
 import {
+  DatetimeAdapter,
+  MTX_DATETIME_FORMATS,
+  MtxDatetimeFormats,
+} from '@ng-matero/extensions/core';
+import {
+  MtxAMPM,
   MtxCalendar,
+  MtxCalendarView,
+  MtxClockView,
   MtxDatetimepicker,
   MtxDatetimepickerFilterType,
   MtxDatetimepickerInput,
@@ -23,7 +46,7 @@ import {
 import { TranslateService } from '@ngx-translate/core';
 import * as _moment from 'moment';
 import { default as _rollupMoment } from 'moment';
-import { Subscription } from 'rxjs';
+import { Subject, Subscription, takeUntil } from 'rxjs';
 
 const moment = _rollupMoment || _moment;
 
@@ -88,6 +111,7 @@ export class DatetimepickerDemoComponent implements OnInit, OnDestroy {
   max: moment.Moment;
   start: moment.Moment;
   filter: (date: moment.Moment | null, type: MtxDatetimepickerFilterType) => boolean;
+  customHeader = CustomExampleHeader;
 
   translateSubscription!: Subscription;
 
@@ -143,5 +167,196 @@ export class DatetimepickerDemoComponent implements OnInit, OnDestroy {
 
   ngOnDestroy() {
     this.translateSubscription.unsubscribe();
+  }
+}
+
+/** Custom header component for datepicker. */
+@Component({
+  selector: 'dev-header',
+  styles: `
+
+  `,
+  template: `
+    @if (type !== 'time') {
+      <button
+        mat-button
+        type="button"
+        class="mtx-calendar-header-year"
+        [class.active]="currentView === 'year' || currentView === 'multi-year'"
+        [attr.aria-label]="_yearButtonLabel"
+        (click)="_yearClicked()"
+      >
+        <span>{{ _yearButtonText }}</span>
+        @if (multiYearSelector || type === 'year') {
+          <svg
+            class="mtx-calendar-header-year-dropdown"
+            matButtonIcon
+            iconPositionEnd
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+          >
+            <path d="M7,10L12,15L17,10H7Z" />
+          </svg>
+        }
+      </button>
+    }
+    @if (type !== 'year') {
+      <div class="mtx-calendar-header-date-time">
+        @if (type !== 'time') {
+          <button
+            mat-button
+            type="button"
+            class="mtx-calendar-header-date"
+            [class.active]="currentView === 'month'"
+            [class.not-clickable]="type === 'month'"
+            [attr.aria-label]="_dateButtonLabel"
+            (click)="_dateClicked()"
+          >
+            {{ _dateButtonText }}
+          </button>
+        }
+        @if (type.endsWith('time')) {
+          <span class="mtx-calendar-header-time" [class.active]="currentView === 'clock'">
+            <span class="mtx-calendar-header-hour-minute-container">
+              <button
+                mat-button
+                type="button"
+                class="mtx-calendar-header-hours"
+                [class.active]="_clockView === 'hour'"
+                [attr.aria-label]="_hourButtonLabel"
+                (click)="_hoursClicked()"
+              >
+                {{ _hoursButtonText }}
+              </button>
+              <span class="mtx-calendar-header-hour-minute-separator">:</span>
+              <button
+                mat-button
+                type="button"
+                class="mtx-calendar-header-minutes"
+                [class.active]="_clockView === 'minute'"
+                [attr.aria-label]="_minuteButtonLabel"
+                (click)="_minutesClicked()"
+              >
+                {{ _minutesButtonText }}
+              </button>
+            </span>
+            @if (twelvehour) {
+              <span class="mtx-calendar-header-ampm-container">
+                <button
+                  mat-button
+                  type="button"
+                  class="mtx-calendar-header-ampm"
+                  [class.active]="_AMPM === 'AM'"
+                  aria-label="AM"
+                  (click)="_ampmClicked('AM')"
+                >
+                  AM
+                </button>
+                <button
+                  mat-button
+                  type="button"
+                  class="mtx-calendar-header-ampm"
+                  [class.active]="_AMPM === 'PM'"
+                  aria-label="PM"
+                  (click)="_ampmClicked('PM')"
+                >
+                  PM
+                </button>
+              </span>
+            }
+          </span>
+        }
+      </div>
+
+      This is an example header component for the datepicker.
+    }
+  `,
+  standalone: true,
+  imports: [MatButtonModule, MatIconModule],
+})
+export class CustomExampleHeader<D> {
+  constructor(
+    private _calendar: MtxCalendar<D>,
+    @Optional() public _dateAdapter: DatetimeAdapter<D>,
+    @Optional() @Inject(MTX_DATETIME_FORMATS) private _dateFormats: MtxDatetimeFormats,
+    cdr: ChangeDetectorRef
+  ) {}
+
+  get currentView(): MtxCalendarView {
+    return this._calendar.currentView;
+  }
+
+  get type(): string {
+    return this._calendar.type;
+  }
+
+  get twelvehour(): boolean {
+    return this._calendar.twelvehour;
+  }
+
+  get _yearButtonLabel(): string {
+    return this._calendar._yearButtonLabel;
+  }
+
+  get _yearButtonText(): string {
+    return this._calendar._yearButtonText;
+  }
+
+  get _dateButtonLabel(): string {
+    return this._calendar._dateButtonLabel;
+  }
+
+  get _dateButtonText(): string {
+    return this._calendar._dateButtonText;
+  }
+
+  get _hourButtonLabel(): string {
+    return this._calendar._hourButtonLabel;
+  }
+
+  get _hoursButtonText(): string {
+    return this._calendar._hoursButtonText;
+  }
+
+  get _minuteButtonLabel(): string {
+    return this._calendar._minuteButtonLabel;
+  }
+
+  get _minutesButtonText(): string {
+    return this._calendar._minutesButtonText;
+  }
+
+  get _clockView(): MtxClockView {
+    return this._calendar._clockView;
+  }
+
+  get _AMPM(): MtxAMPM {
+    return this._calendar._AMPM;
+  }
+
+  _yearClicked(): void {
+    this._calendar._yearClicked();
+  }
+
+  _dateClicked(): void {
+    this._calendar._dateClicked();
+  }
+
+  _hoursClicked(): void {
+    this._calendar._hoursClicked();
+  }
+
+  _minutesClicked(): void {
+    this._calendar._minutesClicked();
+  }
+
+  _ampmClicked(ampm: MtxAMPM): void {
+    this._calendar._ampmClicked(ampm);
+  }
+
+  get multiYearSelector(): boolean {
+    return this._calendar.multiYearSelector;
   }
 }

--- a/projects/docs/src/app/pages/components/datetimepicker/datetimepicker.md
+++ b/projects/docs/src/app/pages/components/datetimepicker/datetimepicker.md
@@ -50,6 +50,7 @@ Exported as: `mtxCalendar`
 | `@Input()`<br>`dateFilter: (date: D, type: MtxDatetimepickerFilterType) => boolean` | Function used to filter which dates are selectable. |
 | `@Input()`<br>`type: MtxDatetimepickerType` | The type of datetimepicker. Default is **`'date'`**. |
 | `@Input()`<br>`multiYearSelector: boolean` | Whether to show multi-year view. Default is **`false`**. |
+| `@Input()`<br>`headerComponent: ComponentType<any>` | Component for a custom header |
 | `@Input()`<br>`twelvehour: boolean` | Whether the clock uses 12 hour format. Default is **`false`**. |
 | `@Input()`<br>`timeInterval: number` | Step over minutes. Default is **`1`**. |
 | `@Input()`<br>`maxDate: D \| null` | The maximum selectable date. |
@@ -83,6 +84,7 @@ Exported as: `mtxDatetimepicker`
 | `@Input()`<br>`mode: MtxDatetimepickerMode` | The display mode of datetimepicker pop-up. Default is **`'auto'`**. |
 | `@Input()`<br>`type: MtxDatetimepickerType` | The type of datetimepicker. Default is **`'date'`**. |
 | `@Input()`<br>`multiYearSelector: boolean` | Whether to show multi-year view. Default is **`false`**. |
+| `@Input()`<br>`calendarHeaderComponent: ComponentType<any>` | Component for a custom header |
 | `@Input()`<br>`twelvehour: boolean` | Whether the clock uses 12 hour format. Default is **`false`**. |
 | `@Input()`<br>`timeInterval: number` | Step over minutes. Default is **`1`**. |
 | `@Input()`<br>`maxDate: D \| null` | The maximum selectable date. |

--- a/projects/docs/src/app/pages/components/datetimepicker/examples/configurable/app.component.html
+++ b/projects/docs/src/app/pages/components/datetimepicker/examples/configurable/app.component.html
@@ -43,6 +43,11 @@
 </section>
 
 <section>
+  <mat-checkbox (change)="showCustomHeader($event)">Custom Header</mat-checkbox>
+</section>
+
+
+<section>
   <label>TimeInterval:</label>
   <mat-slider min="1" max="30" discrete>
     <input matSliderThumb [(ngModel)]="timeInterval">
@@ -61,6 +66,7 @@
                       [type]="type"
                       [mode]="mode"
                       [multiYearSelector]="multiYearSelector"
+                      [calendarHeaderComponent]="customHeader"
                       [startView]="startView"
                       [twelvehour]="twelvehour"
                       [timeInterval]="timeInterval"

--- a/projects/docs/src/app/pages/components/datetimepicker/examples/configurable/app.component.ts
+++ b/projects/docs/src/app/pages/components/datetimepicker/examples/configurable/app.component.ts
@@ -1,13 +1,24 @@
-import { Component } from '@angular/core';
+import { ComponentType } from '@angular/cdk/portal';
+import { ChangeDetectorRef, Component, Inject, Optional } from '@angular/core';
 import { FormsModule, ReactiveFormsModule, UntypedFormControl } from '@angular/forms';
-import { MatCheckbox } from '@angular/material/checkbox';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckbox, MatCheckboxChange } from '@angular/material/checkbox';
 import { MatFormField, MatLabel, MatSuffix } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
 import { MatInput } from '@angular/material/input';
 import { MatRadioButton, MatRadioGroup } from '@angular/material/radio';
 import { MatSlider, MatSliderThumb } from '@angular/material/slider';
 import { provideMomentDatetimeAdapter } from '@ng-matero/extensions-moment-adapter';
 import {
+  DatetimeAdapter,
+  MTX_DATETIME_FORMATS,
+  MtxDatetimeFormats,
+} from '@ng-matero/extensions/core';
+import {
+  MtxAMPM,
+  MtxCalendar,
   MtxCalendarView,
+  MtxClockView,
   MtxDatetimepicker,
   MtxDatetimepickerInput,
   MtxDatetimepickerMode,
@@ -68,6 +79,206 @@ export class AppComponent {
   twelvehour = false;
   timeInterval = 1;
   timeInput = true;
+  customHeader!: any;
 
   datetime = new UntypedFormControl();
+
+  showCustomHeader($event: MatCheckboxChange) {
+    if ($event.checked) {
+      this.customHeader = CustomExampleHeader;
+    } else {
+      this.customHeader = null;
+    }
+  }
+}
+
+/** Custom header component for datepicker. */
+@Component({
+  selector: 'dev-header',
+  styles: `
+
+  `,
+  template: `
+    @if (type !== 'time') {
+      <button
+        mat-button
+        type="button"
+        class="mtx-calendar-header-year"
+        [class.active]="currentView === 'year' || currentView === 'multi-year'"
+        [attr.aria-label]="_yearButtonLabel"
+        (click)="_yearClicked()"
+      >
+        <span>{{ _yearButtonText }}</span>
+        @if (multiYearSelector || type === 'year') {
+          <svg
+            class="mtx-calendar-header-year-dropdown"
+            matButtonIcon
+            iconPositionEnd
+            width="24"
+            height="24"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+          >
+            <path d="M7,10L12,15L17,10H7Z" />
+          </svg>
+        }
+      </button>
+    }
+    @if (type !== 'year') {
+      <div class="mtx-calendar-header-date-time">
+        @if (type !== 'time') {
+          <button
+            mat-button
+            type="button"
+            class="mtx-calendar-header-date"
+            [class.active]="currentView === 'month'"
+            [class.not-clickable]="type === 'month'"
+            [attr.aria-label]="_dateButtonLabel"
+            (click)="_dateClicked()"
+          >
+            {{ _dateButtonText }}
+          </button>
+        }
+        @if (type.endsWith('time')) {
+          <span class="mtx-calendar-header-time" [class.active]="currentView === 'clock'">
+            <span class="mtx-calendar-header-hour-minute-container">
+              <button
+                mat-button
+                type="button"
+                class="mtx-calendar-header-hours"
+                [class.active]="_clockView === 'hour'"
+                [attr.aria-label]="_hourButtonLabel"
+                (click)="_hoursClicked()"
+              >
+                {{ _hoursButtonText }}
+              </button>
+              <span class="mtx-calendar-header-hour-minute-separator">:</span>
+              <button
+                mat-button
+                type="button"
+                class="mtx-calendar-header-minutes"
+                [class.active]="_clockView === 'minute'"
+                [attr.aria-label]="_minuteButtonLabel"
+                (click)="_minutesClicked()"
+              >
+                {{ _minutesButtonText }}
+              </button>
+            </span>
+            @if (twelvehour) {
+              <span class="mtx-calendar-header-ampm-container">
+                <button
+                  mat-button
+                  type="button"
+                  class="mtx-calendar-header-ampm"
+                  [class.active]="_AMPM === 'AM'"
+                  aria-label="AM"
+                  (click)="_ampmClicked('AM')"
+                >
+                  AM
+                </button>
+                <button
+                  mat-button
+                  type="button"
+                  class="mtx-calendar-header-ampm"
+                  [class.active]="_AMPM === 'PM'"
+                  aria-label="PM"
+                  (click)="_ampmClicked('PM')"
+                >
+                  PM
+                </button>
+              </span>
+            }
+          </span>
+        }
+      </div>
+
+      This is an example header component for the datepicker.
+    }
+  `,
+  standalone: true,
+  imports: [MatButtonModule, MatIconModule],
+})
+export class CustomExampleHeader<D> {
+  constructor(
+    private _calendar: MtxCalendar<D>,
+    @Optional() public _dateAdapter: DatetimeAdapter<D>,
+    @Optional() @Inject(MTX_DATETIME_FORMATS) private _dateFormats: MtxDatetimeFormats,
+    cdr: ChangeDetectorRef
+  ) {}
+
+  get currentView(): MtxCalendarView {
+    return this._calendar.currentView;
+  }
+
+  get type(): string {
+    return this._calendar.type;
+  }
+
+  get twelvehour(): boolean {
+    return this._calendar.twelvehour;
+  }
+
+  get _yearButtonLabel(): string {
+    return this._calendar._yearButtonLabel;
+  }
+
+  get _yearButtonText(): string {
+    return this._calendar._yearButtonText;
+  }
+
+  get _dateButtonLabel(): string {
+    return this._calendar._dateButtonLabel;
+  }
+
+  get _dateButtonText(): string {
+    return this._calendar._dateButtonText;
+  }
+
+  get _hourButtonLabel(): string {
+    return this._calendar._hourButtonLabel;
+  }
+
+  get _hoursButtonText(): string {
+    return this._calendar._hoursButtonText;
+  }
+
+  get _minuteButtonLabel(): string {
+    return this._calendar._minuteButtonLabel;
+  }
+
+  get _minutesButtonText(): string {
+    return this._calendar._minutesButtonText;
+  }
+
+  get _clockView(): MtxClockView {
+    return this._calendar._clockView;
+  }
+
+  get _AMPM(): MtxAMPM {
+    return this._calendar._AMPM;
+  }
+
+  _yearClicked(): void {
+    this._calendar._yearClicked();
+  }
+
+  _dateClicked(): void {
+    this._calendar._dateClicked();
+  }
+
+  _hoursClicked(): void {
+    this._calendar._hoursClicked();
+  }
+
+  _minutesClicked(): void {
+    this._calendar._minutesClicked();
+  }
+
+  _ampmClicked(ampm: MtxAMPM): void {
+    this._calendar._ampmClicked(ampm);
+  }
+
+  get multiYearSelector(): boolean {
+    return this._calendar.multiYearSelector;
+  }
 }

--- a/projects/extensions/datetimepicker/calendar.html
+++ b/projects/extensions/datetimepicker/calendar.html
@@ -1,56 +1,60 @@
 <div class="mtx-calendar-header">
-  @if (type !== 'time') {
-    <button
-      mat-button type="button" class="mtx-calendar-header-year"
-      [class.active]="currentView === 'year' || currentView === 'multi-year'"
-      [attr.aria-label]="_yearButtonLabel"
-      (click)="_yearClicked()">
-      <span>{{ _yearButtonText }}</span>
-      @if (multiYearSelector || type === 'year') {
-        <svg
-          class="mtx-calendar-header-year-dropdown" matButtonIcon iconPositionEnd
-          width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M7,10L12,15L17,10H7Z" />
-        </svg>
-      }
-    </button>
-  }
-  @if (type !== 'year') {
-    <div class="mtx-calendar-header-date-time">
-      @if (type !== 'time') {
-        <button
-          mat-button type="button" class="mtx-calendar-header-date"
-          [class.active]="currentView === 'month'"
-          [class.not-clickable]="type === 'month'"
-          [attr.aria-label]="_dateButtonLabel"
-          (click)="_dateClicked()">{{ _dateButtonText }}</button>
-      }
-      @if (type.endsWith('time')) {
-        <span class="mtx-calendar-header-time" [class.active]="currentView === 'clock'">
-          <span class="mtx-calendar-header-hour-minute-container">
-            <button mat-button type="button" class="mtx-calendar-header-hours"
-              [class.active]="_clockView === 'hour'"
-              [attr.aria-label]="_hourButtonLabel"
-              (click)="_hoursClicked()">{{ _hoursButtonText }}</button>
-            <span class="mtx-calendar-header-hour-minute-separator">:</span>
-            <button mat-button type="button" class="mtx-calendar-header-minutes"
-              [class.active]="_clockView === 'minute'"
-              [attr.aria-label]="_minuteButtonLabel"
-              (click)="_minutesClicked()">{{ _minutesButtonText }}</button>
-          </span>
-          @if (twelvehour) {
-            <span class="mtx-calendar-header-ampm-container">
-              <button mat-button type="button" class="mtx-calendar-header-ampm"
-                [class.active]="_AMPM === 'AM'" aria-label="AM"
-                (click)="_ampmClicked('AM')">AM</button>
-              <button mat-button type="button" class="mtx-calendar-header-ampm"
-                [class.active]="_AMPM === 'PM'" aria-label="PM"
-                (click)="_ampmClicked('PM')">PM</button>
+  @if (_calendarHeaderPortal) {
+    <ng-template [cdkPortalOutlet]="_calendarHeaderPortal"></ng-template>
+  } @else {
+    @if (type !== 'time') {
+      <button
+        mat-button type="button" class="mtx-calendar-header-year"
+        [class.active]="currentView === 'year' || currentView === 'multi-year'"
+        [attr.aria-label]="_yearButtonLabel"
+        (click)="_yearClicked()">
+        <span>{{ _yearButtonText }}</span>
+        @if (multiYearSelector || type === 'year') {
+          <svg
+            class="mtx-calendar-header-year-dropdown" matButtonIcon iconPositionEnd
+            width="24" height="24" viewBox="0 0 24 24" fill="currentColor">
+            <path d="M7,10L12,15L17,10H7Z" />
+          </svg>
+        }
+      </button>
+    }
+    @if (type !== 'year') {
+      <div class="mtx-calendar-header-date-time">
+        @if (type !== 'time') {
+          <button
+            mat-button type="button" class="mtx-calendar-header-date"
+            [class.active]="currentView === 'month'"
+            [class.not-clickable]="type === 'month'"
+            [attr.aria-label]="_dateButtonLabel"
+            (click)="_dateClicked()">{{ _dateButtonText }}</button>
+        }
+        @if (type.endsWith('time')) {
+          <span class="mtx-calendar-header-time" [class.active]="currentView === 'clock'">
+            <span class="mtx-calendar-header-hour-minute-container">
+              <button mat-button type="button" class="mtx-calendar-header-hours"
+                [class.active]="_clockView === 'hour'"
+                [attr.aria-label]="_hourButtonLabel"
+                (click)="_hoursClicked()">{{ _hoursButtonText }}</button>
+              <span class="mtx-calendar-header-hour-minute-separator">:</span>
+              <button mat-button type="button" class="mtx-calendar-header-minutes"
+                [class.active]="_clockView === 'minute'"
+                [attr.aria-label]="_minuteButtonLabel"
+                (click)="_minutesClicked()">{{ _minutesButtonText }}</button>
             </span>
-          }
-        </span>
-      }
-    </div>
+            @if (twelvehour) {
+              <span class="mtx-calendar-header-ampm-container">
+                <button mat-button type="button" class="mtx-calendar-header-ampm"
+                  [class.active]="_AMPM === 'AM'" aria-label="AM"
+                  (click)="_ampmClicked('AM')">AM</button>
+                <button mat-button type="button" class="mtx-calendar-header-ampm"
+                  [class.active]="_AMPM === 'PM'" aria-label="PM"
+                  (click)="_ampmClicked('PM')">PM</button>
+              </span>
+            }
+          </span>
+        }
+      </div>
+    }
   }
 </div>
 

--- a/projects/extensions/datetimepicker/calendar.ts
+++ b/projects/extensions/datetimepicker/calendar.ts
@@ -50,6 +50,13 @@ import {
 } from './multi-year-view';
 import { MtxTime } from './time';
 import { MtxYearView } from './year-view';
+import {
+  CdkPortalOutlet,
+  ComponentPortal,
+  ComponentType,
+  Portal,
+  PortalModule,
+} from '@angular/cdk/portal';
 
 /**
  * A calendar that is used as part of the datetimepicker.
@@ -71,6 +78,7 @@ import { MtxYearView } from './year-view';
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
   imports: [
+    CdkPortalOutlet,
     MatButton,
     MatIconButton,
     MtxMonthView,
@@ -99,6 +107,9 @@ export class MtxCalendar<D> implements AfterContentInit, OnDestroy {
   /** Prevent user to select same date time */
   @Input() preventSameDateTimeSelection = false;
 
+  /** Input for custom header component */
+  @Input() headerComponent!: ComponentType<any>;
+
   /** Emits when the currently selected date changes. */
   @Output() selectedChange: EventEmitter<D> = new EventEmitter<D>();
 
@@ -112,6 +123,9 @@ export class MtxCalendar<D> implements AfterContentInit, OnDestroy {
   _clockView: MtxClockView = 'hour';
 
   _calendarState!: string;
+
+  /** A portal containing the header component. */
+  _calendarHeaderPortal!: Portal<any>;
 
   private _intlChanges: Subscription;
 
@@ -342,6 +356,9 @@ export class MtxCalendar<D> implements AfterContentInit, OnDestroy {
   }
 
   ngAfterContentInit() {
+    if (this.headerComponent) {
+      this._calendarHeaderPortal = new ComponentPortal(this.headerComponent);
+    }
     this._activeDate = this.startAt || this._adapter.today();
     this._selectAMPM(this._activeDate);
 

--- a/projects/extensions/datetimepicker/datetimepicker-content.html
+++ b/projects/extensions/datetimepicker/datetimepicker-content.html
@@ -15,6 +15,7 @@
                 [dateFilter]="datetimepicker._dateFilter"
                 [multiYearSelector]="datetimepicker.multiYearSelector"
                 [preventSameDateTimeSelection]="datetimepicker.preventSameDateTimeSelection"
+                [headerComponent]="datetimepicker.calendarHeaderComponent"
                 [timeInterval]="datetimepicker.timeInterval"
                 [twelvehour]="datetimepicker.twelvehour"
                 [selected]="datetimepicker._selected"

--- a/projects/extensions/datetimepicker/datetimepicker.ts
+++ b/projects/extensions/datetimepicker/datetimepicker.ts
@@ -9,7 +9,7 @@ import {
   ScrollStrategy,
 } from '@angular/cdk/overlay';
 import { _getFocusedElementPierceShadowDom } from '@angular/cdk/platform';
-import { ComponentPortal } from '@angular/cdk/portal';
+import { CdkPortalOutlet, ComponentPortal, ComponentType } from '@angular/cdk/portal';
 import { DOCUMENT, NgClass } from '@angular/common';
 import {
   AfterContentInit,
@@ -104,7 +104,7 @@ export const MTX_DATETIMEPICKER_SCROLL_STRATEGY_FACTORY_PROVIDER = {
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   standalone: true,
-  imports: [MtxCalendar, NgClass],
+  imports: [MtxCalendar, NgClass, CdkPortalOutlet],
 })
 export class MtxDatetimepickerContent<D> implements OnInit, AfterContentInit, OnDestroy {
   @ViewChild(MtxCalendar, { static: true }) _calendar!: MtxCalendar<D>;
@@ -174,6 +174,9 @@ export class MtxDatetimepicker<D> implements OnDestroy {
 
   /** Prevent user to select same date time */
   @Input({ transform: booleanAttribute }) preventSameDateTimeSelection = false;
+
+  /** Input for a custom header component */
+  @Input() calendarHeaderComponent!: ComponentType<any>;
 
   /**
    * Emits new selected date when selected date changes.


### PR DESCRIPTION
This adds the ability to add a custom component as an input on the datetimepicker and calendar. It follows the implementation from angular material. I did not separate the current header part in its own component. Please tell me if you want me to do that.

implements https://github.com/ng-matero/extensions/issues/302