### PR TITLE
feat(#281): added ability to provide custom footer

### DIFF
--- a/projects/dev-app/src/app/datetimepicker/datetimepicker-demo.component.html
+++ b/projects/dev-app/src/app/datetimepicker/datetimepicker-demo.component.html
@@ -173,8 +173,10 @@
   <mat-form-field [color]="themeColor">
     <mat-label>Custom Header</mat-label>
     <mtx-datetimepicker-toggle [for]="datetimePickerCustomHeader" matSuffix></mtx-datetimepicker-toggle>
-    <mtx-datetimepicker #datetimePickerCustomHeader startView="month" [timeInterval]="5"
-    [calendarHeaderComponent]="customHeader"></mtx-datetimepicker>
+    <mtx-datetimepicker #datetimePickerCustomHeader startView="month"
+    [timeInterval]="5"
+    [calendarHeaderComponent]="customHeader"
+    ></mtx-datetimepicker>
     <input [mtxDatetimepicker]="datetimePickerCustomHeader" [max]="tomorrow" [min]="today"
       autocomplete="false" formControlName="dateTime" matInput required>
     @if (group.get('dateTime')?.errors?.required) {
@@ -185,6 +187,17 @@
     }
     @if (group.get('dateTime')?.errors?.mtxDatetimepickerMax) {
       <mat-error>max</mat-error>
+    }
+  </mat-form-field>
+
+  <mat-form-field [color]="themeColor">
+    <mat-label>Custom Footer</mat-label>
+    <mtx-datetimepicker-toggle [for]="datetimePickerCustomFooter" matSuffix></mtx-datetimepicker-toggle>
+    <mtx-datetimepicker #datetimePickerCustomFooter type="date"
+    [calendarFooterComponent]="customFooter"></mtx-datetimepicker>
+    <input [mtxDatetimepicker]="datetimePickerCustomFooter" formControlName="date" matInput>
+    @if (group.get('date')?.errors?.required) {
+      <mat-error>required</mat-error>
     }
   </mat-form-field>
 

--- a/projects/dev-app/src/app/datetimepicker/datetimepicker-demo.component.ts
+++ b/projects/dev-app/src/app/datetimepicker/datetimepicker-demo.component.ts
@@ -25,6 +25,7 @@ import * as _moment from 'moment';
 import { default as _rollupMoment } from 'moment';
 import { Subscription } from 'rxjs';
 import { CustomHeader } from './custom-header.component';
+import { CustomFooter } from 'projects/docs/src/app/pages/components/datetimepicker/examples/configurable/custom-footer.component';
 
 const moment = _rollupMoment || _moment;
 
@@ -91,6 +92,7 @@ export class DatetimepickerDemoComponent implements OnInit, OnDestroy {
   filter: (date: moment.Moment | null, type: MtxDatetimepickerFilterType) => boolean;
 
   customHeader = CustomHeader;
+  customFooter = CustomFooter;
 
   translateSubscription!: Subscription;
 

--- a/projects/docs/src/app/pages/components/datetimepicker/datetimepicker.md
+++ b/projects/docs/src/app/pages/components/datetimepicker/datetimepicker.md
@@ -51,6 +51,7 @@ Exported as: `mtxCalendar`
 | `@Input()`<br>`type: MtxDatetimepickerType` | The type of datetimepicker. Default is **`'date'`**. |
 | `@Input()`<br>`multiYearSelector: boolean` | Whether to show multi-year view. Default is **`false`**. |
 | `@Input()`<br>`headerComponent: ComponentType<any>` | Component for a custom header |
+| `@Input()`<br>`footerComponent: ComponentType<any>` | Component for a custom footer |
 | `@Input()`<br>`twelvehour: boolean` | Whether the clock uses 12 hour format. Default is **`false`**. |
 | `@Input()`<br>`timeInterval: number` | Step over minutes. Default is **`1`**. |
 | `@Input()`<br>`maxDate: D \| null` | The maximum selectable date. |
@@ -85,6 +86,7 @@ Exported as: `mtxDatetimepicker`
 | `@Input()`<br>`type: MtxDatetimepickerType` | The type of datetimepicker. Default is **`'date'`**. |
 | `@Input()`<br>`multiYearSelector: boolean` | Whether to show multi-year view. Default is **`false`**. |
 | `@Input()`<br>`calendarHeaderComponent: ComponentType<any>` | Component for a custom header |
+| `@Input()`<br>`calendarFooterComponent: ComponentType<any>` | Component for a custom footer |
 | `@Input()`<br>`twelvehour: boolean` | Whether the clock uses 12 hour format. Default is **`false`**. |
 | `@Input()`<br>`timeInterval: number` | Step over minutes. Default is **`1`**. |
 | `@Input()`<br>`maxDate: D \| null` | The maximum selectable date. |

--- a/projects/docs/src/app/pages/components/datetimepicker/examples/configurable/app.component.html
+++ b/projects/docs/src/app/pages/components/datetimepicker/examples/configurable/app.component.html
@@ -46,6 +46,10 @@
   <mat-checkbox (change)="showCustomHeader($event)">Custom Header</mat-checkbox>
 </section>
 
+<section>
+  <mat-checkbox (change)="showCustomFooter($event)">Custom Footer</mat-checkbox>
+</section>
+
 
 <section>
   <label>TimeInterval:</label>
@@ -67,6 +71,7 @@
                       [mode]="mode"
                       [multiYearSelector]="multiYearSelector"
                       [calendarHeaderComponent]="customHeader"
+                      [calendarFooterComponent]="customFooter"
                       [startView]="startView"
                       [twelvehour]="twelvehour"
                       [timeInterval]="timeInterval"

--- a/projects/docs/src/app/pages/components/datetimepicker/examples/configurable/app.component.ts
+++ b/projects/docs/src/app/pages/components/datetimepicker/examples/configurable/app.component.ts
@@ -15,6 +15,7 @@ import {
   MtxDatetimepickerType,
 } from '@ng-matero/extensions/datetimepicker';
 import { CustomHeader } from './custom-header.component';
+import { CustomFooter } from './custom-footer.component';
 
 @Component({
   selector: 'datetimepicker-example',
@@ -70,6 +71,7 @@ export class AppComponent {
   timeInterval = 1;
   timeInput = true;
   customHeader!: any;
+  customFooter!: any;
 
   datetime = new UntypedFormControl();
 
@@ -78,6 +80,13 @@ export class AppComponent {
       this.customHeader = CustomHeader;
     } else {
       this.customHeader = null;
+    }
+  }
+  showCustomFooter($event: MatCheckboxChange) {
+    if ($event.checked) {
+      this.customFooter = CustomFooter;
+    } else {
+      this.customFooter = null;
     }
   }
 }

--- a/projects/docs/src/app/pages/components/datetimepicker/examples/configurable/custom-footer.component.ts
+++ b/projects/docs/src/app/pages/components/datetimepicker/examples/configurable/custom-footer.component.ts
@@ -1,0 +1,136 @@
+import { Component } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { DatetimeAdapter } from '@ng-matero/extensions/core';
+import {
+  MtxCalendar,
+  MtxCalendarView,
+  MtxMonthView,
+  MtxClock,
+  MtxMultiYearView,
+  MtxTime,
+  MtxYearView,
+  MtxDatetimepickerType,
+  mtxDatetimepickerAnimations,
+} from '@ng-matero/extensions/datetimepicker';
+
+/** Custom footer component for datetimepicker. */
+@Component({
+  selector: 'custom-footer',
+  styles: [
+    `
+      :host {
+        display: flex;
+        flex: 1;
+        align-items: flex-end;
+        justify-content: flex-end;
+      }
+    `,
+  ],
+  template: `
+    @if (this.type === 'datetime' && this.currentView === 'clock') {
+      <div class="mtx-calendar-buttons">
+        <button mat-button type="button" (click)="handleClear()">Clear</button>
+        <button mat-button type="button" (click)="handleOk()">Ok</button>
+        <button mat-button type="button" (click)="handleCancel()">Cancel</button>
+      </div>
+    }
+
+    @if (this.type !== 'datetime') {
+      <div class="mtx-calendar-buttons">
+        <button mat-button type="button" (click)="handleClear()">Clear</button>
+        <button mat-button type="button" (click)="handleOk()">Ok</button>
+        <button mat-button type="button" (click)="handleCancel()">Cancel</button>
+      </div>
+    }
+  `,
+  standalone: true,
+  animations: [mtxDatetimepickerAnimations.slideCalendar],
+  imports: [
+    MatButtonModule,
+    MatIconModule,
+    MtxMonthView,
+    MtxYearView,
+    MtxMultiYearView,
+    MtxTime,
+    MtxClock,
+  ],
+})
+export class CustomFooter<D> {
+  constructor(
+    private _calendar: MtxCalendar<D>,
+    private _adapter: DatetimeAdapter<D>
+  ) {}
+
+  get currentView(): MtxCalendarView {
+    return this._calendar.currentView;
+  }
+
+  get type(): MtxDatetimepickerType {
+    return this._calendar.type;
+  }
+
+  handleOk() {
+    switch (this._calendar.type) {
+      case 'time':
+        if (this._calendar._activeDate) {
+          this._calendar.preventEmittingSameDateSelection(this._calendar._activeDate);
+          this._calendar._userSelection.emit();
+        }
+        break;
+      case 'month':
+        if (this._calendar._activeDate) {
+          this._calendar.preventEmittingSameDateSelection(this._calendar._activeDate);
+          this._calendar._userSelection.emit();
+        }
+        break;
+      case 'year':
+        if (this._calendar._activeDate) {
+          if (
+            !this._adapter.sameYear(this._calendar._activeDate, this._calendar.selected as D) ||
+            !this._calendar.preventSameDateTimeSelection
+          ) {
+            const normalizedDate = this._adapter.createDatetime(
+              this._adapter.getYear(this._calendar._activeDate),
+              0,
+              1,
+              0,
+              0
+            );
+            this._calendar.selectedChange.emit(normalizedDate);
+          }
+          this._calendar._userSelection.emit();
+        }
+        break;
+      case 'date':
+        if (this._calendar._activeDate) {
+          this._calendar.preventEmittingSameDateSelection(this._calendar._activeDate);
+          this._calendar._userSelection.emit();
+        }
+        break;
+      case 'datetime':
+        if (this._calendar._activeDate) {
+          if (this.currentView !== 'clock') {
+            this._calendar._dateSelected(this._calendar._activeDate);
+          } else {
+            this._calendar.preventEmittingSameDateSelection(this._calendar._activeDate);
+            this._calendar._userSelection.emit();
+          }
+        }
+        break;
+      default:
+        // Optionally handle other cases or do nothing
+        break;
+    }
+  }
+
+  handleClear() {
+    this._calendar.selectedChange.emit();
+    this._calendar.selected = null;
+    this._calendar._activeDate = this._adapter.today();
+  }
+
+  handleCancel() {
+    this._calendar._userSelection.emit();
+  }
+}

--- a/projects/docs/src/app/pages/components/datetimepicker/examples/configurable/index.ts
+++ b/projects/docs/src/app/pages/components/datetimepicker/examples/configurable/index.ts
@@ -19,6 +19,16 @@ const datetimepickerConfigurableExampleConfig = {
       content: require('!!highlight-loader?raw=true&lang=scss!./app.component.scss'),
       filecontent: require('!!raw-loader!./app.component.scss'),
     },
+    {
+      file: 'custom-header.component.ts',
+      content: require('!!highlight-loader?raw=true&lang=typescript!./custom-header.component.ts'),
+      filecontent: require('!!raw-loader!./custom-header.component.ts'),
+    },
+    {
+      file: 'custom-footer.component.ts',
+      content: require('!!highlight-loader?raw=true&lang=typescript!./custom-footer.component.ts'),
+      filecontent: require('!!raw-loader!./custom-footer.component.ts'),
+    },
   ],
 };
 

--- a/projects/extensions/datetimepicker/calendar.html
+++ b/projects/extensions/datetimepicker/calendar.html
@@ -99,6 +99,7 @@
         [activeDate]="_activeDate"
         [dateFilter]="_dateFilterForViews"
         [selected]="selected!"
+        [customFooter]="!!_customFooterPortal"
         [type]="type">
       </mtx-month-view>
     }
@@ -109,6 +110,7 @@
         [activeDate]="_activeDate"
         [dateFilter]="_dateFilterForViews"
         [selected]="selected!"
+        [customFooter]="!!_customFooterPortal"
         [type]="type">
       </mtx-year-view>
     }
@@ -121,6 +123,7 @@
         [maxDate]="maxDate"
         [minDate]="minDate"
         [selected]="selected!"
+        [customFooter]="!!_customFooterPortal"
         [type]="type">
       </mtx-multi-year-view>
     }
@@ -139,6 +142,7 @@
           [interval]="timeInterval"
           [maxDate]="maxDate"
           [minDate]="minDate"
+          [customFooter]="!!_customFooterPortal"
           [selected]="_activeDate">
         </mtx-time>
       } @else {
@@ -152,9 +156,14 @@
           [minDate]="minDate"
           [selected]="_activeDate"
           [startView]="_clockView"
-          [twelvehour]="twelvehour">
+          [twelvehour]="twelvehour"
+          [customFooter]="!!_customFooterPortal">
         </mtx-clock>
       }
     }
+  }
+
+  @if (_customFooterPortal) {
+    <ng-template [cdkPortalOutlet]="_customFooterPortal"></ng-template>
   }
 </div>

--- a/projects/extensions/datetimepicker/calendar.scss
+++ b/projects/extensions/datetimepicker/calendar.scss
@@ -199,6 +199,8 @@ $_tokens: tokens-mtx-datetimepicker.$prefix, tokens-mtx-datetimepicker.get-token
 }
 
 .mtx-calendar-content {
+  display: flex;
+  flex-direction: column;
   width: 100%;
   padding: $calendar-padding;
   outline: none;

--- a/projects/extensions/datetimepicker/clock.ts
+++ b/projects/extensions/datetimepicker/clock.ts
@@ -59,6 +59,9 @@ export class MtxClock<D> implements AfterContentInit, OnDestroy, OnChanges {
   /** Whether the clock uses 12 hour format. */
   @Input({ transform: booleanAttribute }) twelvehour: boolean = false;
 
+  /** This will be true when a custom Footer Component is passed */
+  @Input({ transform: booleanAttribute }) customFooter: boolean = false;
+
   /** Whether the time is now in AM or PM. */
   @Input() AMPM: MtxAMPM = 'AM';
 
@@ -209,9 +212,10 @@ export class MtxClock<D> implements AfterContentInit, OnDestroy, OnChanges {
 
     if (this._timeChanged) {
       this.selectedChange.emit(this.activeDate);
-      if (!this._hourView) {
-        this._userSelection.emit();
-      }
+      if (!this.customFooter)
+        if (!this._hourView) {
+          this._userSelection.emit();
+        }
     }
   };
 

--- a/projects/extensions/datetimepicker/datetimepicker-content.html
+++ b/projects/extensions/datetimepicker/datetimepicker-content.html
@@ -16,6 +16,7 @@
                 [multiYearSelector]="datetimepicker.multiYearSelector"
                 [preventSameDateTimeSelection]="datetimepicker.preventSameDateTimeSelection"
                 [headerComponent]="datetimepicker.calendarHeaderComponent"
+                [footerComponent]="datetimepicker.calendarFooterComponent"
                 [timeInterval]="datetimepicker.timeInterval"
                 [twelvehour]="datetimepicker.twelvehour"
                 [selected]="datetimepicker._selected"

--- a/projects/extensions/datetimepicker/datetimepicker.ts
+++ b/projects/extensions/datetimepicker/datetimepicker.ts
@@ -181,6 +181,9 @@ export class MtxDatetimepicker<D> implements OnDestroy {
   /** Input for a custom header component */
   @Input() calendarHeaderComponent!: ComponentType<any>;
 
+  /** input for custom options below the calendar */
+  @Input() calendarFooterComponent!: ComponentType<any>;
+
   /**
    * Emits new selected date when selected date changes.
    * @deprecated Switch to the `dateChange` and `dateInput` binding on the input element.
@@ -366,9 +369,9 @@ export class MtxDatetimepicker<D> implements OnDestroy {
   }
 
   /** Selects the given date */
-  _select(date: D): void {
+  _select(date: D | undefined): void {
     const oldValue = this._selected;
-    this._selected = date;
+    this._selected = date || null;
     if (!this._dateAdapter.sameDatetime(oldValue, this._selected)) {
       this.selectedChanged.emit(date);
     }

--- a/projects/extensions/datetimepicker/month-view.ts
+++ b/projects/extensions/datetimepicker/month-view.ts
@@ -41,6 +41,9 @@ export class MtxMonthView<D> implements AfterContentInit {
   /** A function used to filter which dates are selectable. */
   @Input() dateFilter!: (date: D) => boolean;
 
+  /** Whether the custom footer is added in the parent. */
+  @Input() customFooter: boolean = false;
+
   /** Emits when a new date is selected. */
   @Output() selectedChange = new EventEmitter<D>();
 
@@ -136,16 +139,21 @@ export class MtxMonthView<D> implements AfterContentInit {
 
   /** Handles when a new date is selected. */
   _dateSelected(date: number) {
-    this.selectedChange.emit(
-      this._adapter.createDatetime(
-        this._adapter.getYear(this.activeDate),
-        this._adapter.getMonth(this.activeDate),
-        date,
-        this._adapter.getHour(this.activeDate),
-        this._adapter.getMinute(this.activeDate)
-      )
+    const dateObject = this._adapter.createDatetime(
+      this._adapter.getYear(this.activeDate),
+      this._adapter.getMonth(this.activeDate),
+      date,
+      this._adapter.getHour(this.activeDate),
+      this._adapter.getMinute(this.activeDate)
     );
-    if (this.type === 'date') {
+
+    this.selectedChange.emit(dateObject);
+
+    if (this.customFooter) {
+      this.selected = dateObject;
+    }
+
+    if (this.type === 'date' && !this.customFooter) {
       this._userSelection.emit();
     }
   }

--- a/projects/extensions/datetimepicker/multi-year-view.ts
+++ b/projects/extensions/datetimepicker/multi-year-view.ts
@@ -43,6 +43,9 @@ export class MtxMultiYearView<D> implements AfterContentInit {
   /** A function used to filter which dates are selectable. */
   @Input() dateFilter!: (date: D) => boolean;
 
+  /** Whether the custom footer is added in the parent. */
+  @Input() customFooter: boolean = false;
+
   /** Emits when a new month is selected. */
   @Output() selectedChange = new EventEmitter<D>();
 
@@ -145,20 +148,24 @@ export class MtxMultiYearView<D> implements AfterContentInit {
     const month = this._adapter.getMonth(this.activeDate);
     const normalizedDate = this._adapter.createDatetime(year, month, 1, 0, 0);
 
-    this.selectedChange.emit(
-      this._adapter.createDatetime(
-        year,
-        month,
-        Math.min(
-          this._adapter.getDate(this.activeDate),
-          this._adapter.getNumDaysInMonth(normalizedDate)
-        ),
-        this._adapter.getHour(this.activeDate),
-        this._adapter.getMinute(this.activeDate)
-      )
+    const date = this._adapter.createDatetime(
+      year,
+      month,
+      Math.min(
+        this._adapter.getDate(this.activeDate),
+        this._adapter.getNumDaysInMonth(normalizedDate)
+      ),
+      this._adapter.getHour(this.activeDate),
+      this._adapter.getMinute(this.activeDate)
     );
 
-    if (this.type === 'year') {
+    this.selectedChange.emit(date);
+
+    if (this.customFooter) {
+      this.selected = date;
+    }
+
+    if (this.type === 'year' && !this.customFooter) {
       this._userSelection.emit();
     }
   }

--- a/projects/extensions/datetimepicker/time.html
+++ b/projects/extensions/datetimepicker/time.html
@@ -55,13 +55,14 @@
   [startView]="clockView"
   [twelvehour]="twelvehour">
 </mtx-clock>
-
-<div class="mtx-time-button-wrapper">
-  <button class="mtx-time-cancel-button" mat-button type="button" (click)="handleCancel()">
-    {{ _datetimepickerIntl.cancelLabel }}
-  </button>
-  <button class="mtx-time-ok-button" mat-button type="button" (click)="handleOk()"
-    [disabled]="minuteInputDirective?.invalid || hourInputDirective?.invalid">
-    {{ _datetimepickerIntl.okLabel }}
-  </button>
-</div>
+@if (!customFooter) {
+  <div class="mtx-time-button-wrapper">
+    <button class="mtx-time-cancel-button" mat-button type="button" (click)="handleCancel()">
+      {{ _datetimepickerIntl.cancelLabel }}
+    </button>
+    <button class="mtx-time-ok-button" mat-button type="button" (click)="handleOk()"
+      [disabled]="minuteInputDirective?.invalid || hourInputDirective?.invalid">
+      {{ _datetimepickerIntl.okLabel }}
+    </button>
+  </div>
+}

--- a/projects/extensions/datetimepicker/time.ts
+++ b/projects/extensions/datetimepicker/time.ts
@@ -256,6 +256,9 @@ export class MtxTime<D> implements OnChanges, AfterViewInit, OnDestroy {
   /** Step over minutes. */
   @Input() interval: number = 1;
 
+  /** Whether the custom footer is added. */
+  @Input() customFooter: boolean = false;
+
   @ViewChild('hourInput', { read: ElementRef<HTMLInputElement> })
   protected hourInputElement: ElementRef<HTMLInputElement> | undefined;
 

--- a/projects/extensions/datetimepicker/year-view.ts
+++ b/projects/extensions/datetimepicker/year-view.ts
@@ -39,6 +39,9 @@ export class MtxYearView<D> implements AfterContentInit {
   /** A function used to filter which dates are selectable. */
   @Input() dateFilter!: (date: D) => boolean;
 
+  /** Whether the custom footer is added in the parent. */
+  @Input() customFooter: boolean = false;
+
   /** Emits when a new month is selected. */
   @Output() selectedChange = new EventEmitter<D>();
 
@@ -129,19 +132,23 @@ export class MtxYearView<D> implements AfterContentInit {
       0
     );
 
-    this.selectedChange.emit(
-      this._adapter.createDatetime(
-        this._adapter.getYear(this.activeDate),
-        month,
-        Math.min(
-          this._adapter.getDate(this.activeDate),
-          this._adapter.getNumDaysInMonth(normalizedDate)
-        ),
-        this._adapter.getHour(this.activeDate),
-        this._adapter.getMinute(this.activeDate)
-      )
+    const date = this._adapter.createDatetime(
+      this._adapter.getYear(this.activeDate),
+      month,
+      Math.min(
+        this._adapter.getDate(this.activeDate),
+        this._adapter.getNumDaysInMonth(normalizedDate)
+      ),
+      this._adapter.getHour(this.activeDate),
+      this._adapter.getMinute(this.activeDate)
     );
-    if (this.type === 'month') {
+
+    this.selectedChange.emit(date);
+    if (this.customFooter) {
+      this.selected = date;
+    }
+
+    if (this.type === 'month' && !this.customFooter) {
       this._userSelection.emit();
     }
   }


### PR DESCRIPTION
This implements https://github.com/ng-matero/extensions/issues/281 and allows every view to have a custom footer with whatever buttons the user may need. 

I made best effort to keep the old functionality while implementing this.

Open to suggestions if you are not happy with anything @nzbin.