### PR TITLE
fix: animation error when popover is no longer visible in view

### DIFF
--- a/projects/extensions/popover/popover-trigger.ts
+++ b/projects/extensions/popover/popover-trigger.ts
@@ -148,6 +148,7 @@ export class MtxPopoverTrigger implements AfterContentInit, OnDestroy {
       this._overlayRef = null;
     }
 
+    this._halt = true;
     this._positionSubscription.unsubscribe();
     this._popoverCloseSubscription.unsubscribe();
     this._closingActionsSubscription.unsubscribe();


### PR DESCRIPTION
ERROR TypeError: Cannot read properties of undefined (reading 'listen') https://github.com/ng-matero/extensions/issues/291