### PR TITLE
Fix mtx select appeareance and vertical alignment when not using placeholder.

### DIFF
--- a/projects/extensions/select/select.scss
+++ b/projects/extensions/select/select.scss
@@ -160,6 +160,7 @@ $_tokens: tokens-mtx-select.$prefix, tokens-mtx-select.get-token-slots();
 
     .ng-arrow-wrapper {
       width: 10px;
+      transform: var(--mat-select-arrow-transform);
     }
 
     $enabled-arrow-color: token-utils.get-token-variable(enabled-arrow-color);

--- a/projects/extensions/select/select.scss
+++ b/projects/extensions/select/select.scss
@@ -57,6 +57,14 @@ $_tokens: tokens-mtx-select.$prefix, tokens-mtx-select.get-token-slots();
       .mat-form-field-hide-placeholder & {
         opacity: 0;
       }
+
+      &:empty::before{
+        content: " ";
+        white-space: pre;
+        width: 1px;
+        display: inline-block;
+        visibility: hidden;
+      }
     }
 
     .ng-has-value .ng-placeholder {


### PR DESCRIPTION
Hi there, 
I hope its ok for me to make this PR.

This PR is a proposal to fix the appearance of the mtx-select component, relative to vertical aligment, and arrow positioning.

Vertical alignment was different whether you set the placeholder property or not, unless you used the following css rule:
```
.mat-form-field {
vertical-align : middle;
}
``` 
It doesn't fix the problem for outline style mat-form-field, but this problem lies in angular material itself (the same behavior can be observed with mat-select )