### PR TITLE
Fix(#361)

### DIFF
--- a/projects/extensions/datetimepicker/calendar.ts
+++ b/projects/extensions/datetimepicker/calendar.ts
@@ -455,7 +455,6 @@ export class MtxCalendar<D> implements AfterContentInit, OnDestroy {
   }
 
   _updateDate(date: D): D {
-    console.log(date);
     if (this.twelvehour) {
       const HOUR = this._adapter.getHour(date);
       if (HOUR === 12) {

--- a/projects/extensions/datetimepicker/calendar.ts
+++ b/projects/extensions/datetimepicker/calendar.ts
@@ -386,6 +386,7 @@ export class MtxCalendar<D> implements AfterContentInit, OnDestroy {
   /** Handles date selection in the month view. */
   _dateSelected(date: D): void {
     if (this.type === 'date') {
+      this._onActiveDateChange(date);
       if (!this._adapter.sameDate(date, this.selected) || !this.preventSameDateTimeSelection) {
         this.selectedChange.emit(date);
       }
@@ -454,6 +455,7 @@ export class MtxCalendar<D> implements AfterContentInit, OnDestroy {
   }
 
   _updateDate(date: D): D {
+    console.log(date);
     if (this.twelvehour) {
       const HOUR = this._adapter.getHour(date);
       if (HOUR === 12) {

--- a/projects/extensions/datetimepicker/datetimepicker.ts
+++ b/projects/extensions/datetimepicker/datetimepicker.ts
@@ -423,7 +423,7 @@ export class MtxDatetimepicker<D> implements OnDestroy {
     if (!this._selected) {
       this._selected = this._dateAdapter.today();
       this.selectedChanged.emit(this._selected);
-    } else if (!this._dateAdapter.sameDatetime(this.oldValue, this._selected)) {
+    } else {
       this.selectedChanged.emit((this._selected as D) || (this.oldValue as D));
     }
     this.close();


### PR DESCRIPTION
When developed the act. buttons the check for sameDate was added as an extra, removing it will ensure we are selecting date in all cases when using act buttons also fixed an issue where the active-date in the header wasn’t applied in month view.

Open for any feedback. :)