### PR TITLE
fix: time-view expression error

### DIFF
--- a/projects/dev-app/src/main.ts
+++ b/projects/dev-app/src/main.ts
@@ -3,6 +3,7 @@ import { FullscreenOverlayContainer, OverlayContainer } from '@angular/cdk/overl
 import { HttpClient, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
 import {
   importProvidersFrom,
+  provideExperimentalCheckNoChangesForDebug,
   provideExperimentalZonelessChangeDetection,
   provideZoneChangeDetection,
 } from '@angular/core';
@@ -47,5 +48,10 @@ bootstrapApplication(AppComponent, {
     cachedAppState.zoneless
       ? provideExperimentalZonelessChangeDetection()
       : provideZoneChangeDetection({ eventCoalescing: true, runCoalescing: true }),
+
+    // verify for check no changes for debug
+    provideExperimentalCheckNoChangesForDebug({
+      interval: 1000,
+    }),
   ],
 }).catch(err => console.error(err));

--- a/projects/extensions/datetimepicker/time-view.html
+++ b/projects/extensions/datetimepicker/time-view.html
@@ -67,7 +67,7 @@
       {{ _datetimepickerIntl.cancelLabel }}
     </button>
     <button class="mtx-time-ok-button" mat-button type="button" (click)="_handleOk()"
-      [disabled]="minuteInputDirective?.invalid || hourInputDirective?.invalid">
+      [disabled]="_minuteInputDirective?.invalid || _hourInputDirective?.invalid">
       {{ _datetimepickerIntl.okLabel }}
     </button>
   </div>

--- a/projects/extensions/datetimepicker/time-view.ts
+++ b/projects/extensions/datetimepicker/time-view.ts
@@ -15,6 +15,7 @@ import {
   OnDestroy,
   Output,
   SimpleChanges,
+  viewChild,
   ViewChild,
   ViewEncapsulation,
 } from '@angular/core';
@@ -278,14 +279,22 @@ export class MtxTimeView<D> implements OnChanges, OnDestroy {
   @ViewChild('hourInput', { read: ElementRef<HTMLInputElement> })
   protected hourInputElement: ElementRef<HTMLInputElement> | undefined;
 
+  protected _hourInputDirective: MtxTimeInput | undefined;
   @ViewChild('hourInput', { read: MtxTimeInput })
-  protected hourInputDirective: MtxTimeInput | undefined;
+  set hourInputDirective(input: MtxTimeInput) {
+    this._hourInputDirective = input;
+    this._changeDetectorRef.detectChanges();
+  }
 
   @ViewChild('minuteInput', { read: ElementRef<HTMLInputElement> })
   protected minuteInputElement: ElementRef<HTMLInputElement> | undefined;
 
+  protected _minuteInputDirective: MtxTimeInput | undefined;
   @ViewChild('minuteInput', { read: MtxTimeInput })
-  protected minuteInputDirective: MtxTimeInput | undefined;
+  set minuteInputDirective(input: MtxTimeInput) {
+    this._hourInputDirective = input;
+    this._changeDetectorRef.detectChanges();
+  }
 
   datetimepickerIntlChangesSubscription: SubscriptionLike;
 
@@ -539,8 +548,8 @@ export class MtxTimeView<D> implements OnChanges, OnDestroy {
       // will make it "40" again then the minuteInputDirective will not have been updated
       // since "40" === "40" same reference so no change detected by directly setting it within
       // this handler, we handle this usecase
-      if (this.minuteInputDirective) {
-        this.minuteInputDirective.timeValue = this.minute;
+      if (this._minuteInputDirective) {
+        this._minuteInputDirective.timeValue = this.minute;
       }
     }
   }


### PR DESCRIPTION
I did some testing here, with these changes the expressionChangedAfterCheckedError does not appear.

I did try to do these changes without using `viewChild` ( signal ) variant to keep in line with the current code, but did not succeed therefore I'm using the newer `viewChild` signal based queries.

I did add the:
`provideExperimentalCheckNoChangesForDebug` in the dev-app which should show errors like these, I think its a good idea to keep it around when making changes so we see these errors and can fix them. Else consumers of the extension library might run into these and we're unaware.

fixes: #409